### PR TITLE
 **Fix GroupBy error related to `include_groups`**

### DIFF
--- a/streamd/analysis/run_analysis.py
+++ b/streamd/analysis/run_analysis.py
@@ -57,7 +57,7 @@ def run_rmsd_analysis(rmsd_files, wdir, unique_id, time_ranges=None,
     # important for paint_by file where all system columns should be presented and used
     if 'directory' in rmsd_merged_data.columns:
         max_num_unique_dirs = rmsd_merged_data.groupby(system_cols).apply(
-            lambda x: len(x['directory'].unique()), include_groups=False).reset_index(drop=True).max()
+            lambda x: len(x['directory'].unique())).reset_index(drop=True).max()
         if max_num_unique_dirs > 1:
             system_cols.append('directory')
 


### PR DESCRIPTION
**Fix GroupBy error related to `include_groups`**:
   - The `groupby.apply()` function was being called with an unsupported keyword argument `include_groups`. This issue was triggered by changes in recent versions of Pandas (2.x) that removed support for this argument.
   - Removed the `include_groups` argument from the lambda function within `groupby.apply()`, resolving the `TypeError`.