### PR TITLE
Revert "Fix `.str.lower()` error in make_lower_case()"

### DIFF
--- a/streamd/analysis/run_analysis.py
+++ b/streamd/analysis/run_analysis.py
@@ -39,7 +39,7 @@ def calc_mean_std_by_ranges_time(rmsd_data, time_ranges, rmsd_system='backbone',
 
 def make_lower_case(df, cols):
     for col in cols:
-        df[col] = df[col].astype(str).str.lower()
+        df[col] = df[col].str.lower()
     return df
 
 def run_rmsd_analysis(rmsd_files, wdir, unique_id, time_ranges=None,


### PR DESCRIPTION
Reverts ci-lab-cz/streamd#40
Using as_type(str) with None values, None is being converting to string and silencing the issue, no None values should be in the system_columns used for discrimination rmsd systems