### PR TITLE
Fix `.str.lower()` error in make_lower_case() for number system ids

### DIFF
--- a/streamd/analysis/run_analysis.py
+++ b/streamd/analysis/run_analysis.py
@@ -39,7 +39,7 @@ def calc_mean_std_by_ranges_time(rmsd_data, time_ranges, rmsd_system='backbone',
 
 def make_lower_case(df, cols):
     for col in cols:
-        df[col] = df[col].str.lower()
+        df[col] = df[col].astype(str).str.lower()
     return df
 
 def run_rmsd_analysis(rmsd_files, wdir, unique_id, time_ranges=None,


### PR DESCRIPTION
**Fix `.str.lower()` error in make_lower_case()**:
   - The original code attempted to apply `.str.lower()` on columns that might contain non-string values, leading to an `AttributeError` when such columns were present. 
   - Updated the function to explicitly convert the column values to strings first using `astype(str)`, making it compatible with `.str` methods regardless of the column data type.