### PR TITLE
Prevent list conversion for boolean flags in config parsing

### DIFF
--- a/streamd/tests/config_cli_test.py
+++ b/streamd/tests/config_cli_test.py
@@ -130,3 +130,16 @@ def test_list_argument_from_config(tmp_path: Path) -> None:
     )
     assert args.steps == [3, 4]
 
+
+def test_store_true_from_config(tmp_path: Path) -> None:
+    """Boolean ``store_true`` options from YAML stay boolean."""
+
+    parser = _make_parser([
+        ("--debug", {"action": "store_true", "default": False}),
+    ])
+
+    config_path = _write_config(tmp_path, {"debug": True})
+
+    args, _ = parse_with_config(parser, ["--config", str(config_path)])
+    assert args.debug is True
+

--- a/streamd/utils/utils.py
+++ b/streamd/utils/utils.py
@@ -59,14 +59,7 @@ def parse_with_config(parser: argparse.ArgumentParser, cli_args: Iterable[str]) 
                 continue
             value = config_args[dest]
 
-            # ``argparse`` represents ``store_true``/``store_false`` actions with
-            # ``nargs`` set to ``0``.  These flags are inherently scalar booleans
-            # and should not be treated as multi-value options.  Previously, the
-            # ``nargs`` check considered any value other than ``None`` or ``?`` as
-            # indicating a list-like argument, which converted config-provided
-            # booleans into single-item lists (e.g. ``debug: True`` became
-            # ``[True]``).  Excluding ``0`` from this branch keeps such flags as
-            # plain booleans.
+            #argparse represents store_true/store_false actions with nargs set to 0
             if action.nargs not in (None, '?', 0):
                 if isinstance(value, str):
                     value = value.split()

--- a/streamd/utils/utils.py
+++ b/streamd/utils/utils.py
@@ -59,7 +59,15 @@ def parse_with_config(parser: argparse.ArgumentParser, cli_args: Iterable[str]) 
                 continue
             value = config_args[dest]
 
-            if action.nargs not in (None, '?'):
+            # ``argparse`` represents ``store_true``/``store_false`` actions with
+            # ``nargs`` set to ``0``.  These flags are inherently scalar booleans
+            # and should not be treated as multi-value options.  Previously, the
+            # ``nargs`` check considered any value other than ``None`` or ``?`` as
+            # indicating a list-like argument, which converted config-provided
+            # booleans into single-item lists (e.g. ``debug: True`` became
+            # ``[True]``).  Excluding ``0`` from this branch keeps such flags as
+            # plain booleans.
+            if action.nargs not in (None, '?', 0):
                 if isinstance(value, str):
                     value = value.split()
                 elif not isinstance(value, (list, tuple)):


### PR DESCRIPTION
## Summary
- ensure `parse_with_config` keeps `store_true`/`store_false` options as booleans
- add regression test for boolean `store_true` option loaded from YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46945ab0c832b8542b23c8c5826da