### PR TITLE
Enable gmxMMPBSA GBSA and PBSA parsing

### DIFF
--- a/streamd/tests/results_parse_test.py
+++ b/streamd/tests/results_parse_test.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from streamd.run_gbsa import parse_gmxMMPBSA_results
+from streamd.run_gbsa import parse_gmxMMPBSA_results, parse_gmxMMPBSA_output
 
 def test_parse_gmxMMPBSA_results(tmp_path):
     content = """GENERALIZED BORN:
@@ -25,3 +25,34 @@ Frame #,BOND,ANGLE
     assert gb_complex == 1.0
     pb_ligand = df[(df["Region"] == "Ligand") & (df["Method"] == "PB")]["ANGLE"].iloc[0]
     assert pb_ligand == 6.0
+
+
+def test_parse_gmxMMPBSA_output(tmp_path):
+    content = """ENTROPY RESULTS (INTERACTION ENTROPY):
+Energy Method          Entropy σ(Int. Energy)    Average           SD        SEM
+-------------------------------------------------------------------------------
+GB                          IE          3.28       0.63         0.99       0.44
+
+Energy Method          Entropy σ(Int. Energy)    Average           SD        SEM
+-------------------------------------------------------------------------------
+PB                          IE          3.28       0.63         0.99       0.44
+
+GENERALIZED BORN:
+Delta (Complex - Receptor - Ligand):
+Energy Component       Average     SD(Prop.)         SD   SEM(Prop.)        SEM
+ΔTOTAL                  -51.34          0.80       2.82         0.36       1.26
+Using Interaction Entropy Approximation:
+ΔG binding =    -50.71 +/-    2.99
+
+POISSON BOLTZMANN:
+Delta (Complex - Receptor - Ligand):
+Energy Component       Average     SD(Prop.)         SD   SEM(Prop.)        SEM
+ΔTOTAL                  -46.69          1.08       2.69         0.48       1.20
+Using Interaction Entropy Approximation:
+ΔG binding =    -46.06 +/-    2.87
+"""
+    f = tmp_path / "FINAL_RESULTS_MMPBSA_test.dat"
+    f.write_text(content)
+    res = parse_gmxMMPBSA_output(f)
+    assert res["GBSA"]["ΔTOTAL_Average"] == "-51.34"
+    assert res["PBSA"]["ΔTOTAL_Average"] == "-46.69"


### PR DESCRIPTION
## Summary
- allow using run_gbsa parsing helpers without heavy MDAnalysis/RDKit dependencies by importing optional utilities lazily
- add regression test to ensure FINAL_RESULTS_MMPBSA.dat files yield separate GBSA and PBSA energy outputs

## Testing
- `pytest streamd/tests/results_parse_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5fe961e44832b9a10a6e89f6cf82f