### PR TITLE
Auto-enable per-residue decomposition from mmpbsa.in

### DIFF
--- a/streamd/tests/decomp_dat_parser_test.py
+++ b/streamd/tests/decomp_dat_parser_test.py
@@ -58,6 +58,8 @@ def test_start_aggregates_decomp_dat(tmp_path):
         "Frame #,Residue,Internal,van der Waals,Electrostatic,Polar Solvation,Non-Polar Solv.,TOTAL\n"
         "1,R:A:ALA:1,1,2,3,4,5,6\n"
     )
+    mmpbsa_in = tmp_path / "mmpbsa.in"
+    mmpbsa_in.write_text("&general\n/\n&decomp\n/\n")
     start(
         wdir_to_run=None,
         tpr=None,
@@ -65,7 +67,7 @@ def test_start_aggregates_decomp_dat(tmp_path):
         topol=None,
         index=None,
         out_wdir=tmp_path,
-        mmpbsa=None,
+        mmpbsa=str(mmpbsa_in),
         ncpu=1,
         ligand_resid="UNL",
         append_protein_selection=None,
@@ -75,7 +77,6 @@ def test_start_aggregates_decomp_dat(tmp_path):
         gmxmmpbsa_out_files=[str(results_dat)],
         clean_previous=False,
         debug=False,
-        decomp=True,
     )
     assert (tmp_path / "GBSA_decomp_avg_test.csv").is_file()
     assert (tmp_path / "PBSA_decomp_avg_test.csv").is_file()


### PR DESCRIPTION
## Summary
- Automatically turn on per-residue decomposition when `&decomp` block exists in `mmpbsa.in`
- Drop the `--decomp` command-line flag and rely on `mmpbsa.in` contents

------
https://chatgpt.com/codex/tasks/task_e_68a619060354832b8cd5c5ac628b83d1