### PR TITLE
Allow configuring solvation box from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ run_md -h
 usage: run_md [-h] [-p FILENAME] [-d WDIR] [-l FILENAME] [--cofactor FILENAME] [--clean_previous_md] [--hostfile FILENAME] [-c INTEGER] [--mdrun_per_node INTEGER]
               [--device cpu] [--gpu_ids GPU ID [GPU ID ...]] [--ntmpi_per_gpu int] [--topol topol.top]
               [--topol_itp topol_chainA.itp topol_chainB.itp [topol_chainA.itp topol_chainB.itp ...]] [--posre posre.itp [posre.itp ...]]
-              [--protein_forcefield amber99sb-ildn] [--noignh] [--md_time ns] [--npt_time ps] [--nvt_time ps] [--seed int] [--no_dr] [--not_clean_backup_files]
+              [--protein_forcefield amber99sb-ildn] [--noignh] [--md_time ns] [--npt_time ps] [--nvt_time ps] [--seed int] [--box_type cubic] [--box_distance nm] [--no_dr] [--not_clean_backup_files]
               [--steps [STEPS ...]] [--mdp_dir Path to a directory with specific mdp files] [--wdir_to_continue DIRNAME [DIRNAME ...]] [-o OUT_SUFFIX]
               [--save_traj_without_water] [--deffnm preffix for md files] [--tpr FILENAME] [--cpt FILENAME] [--xtc FILENAME] [--ligand_list_file all_ligand_resid.txt]
               [--ligand_id UNL] [--activate_gaussian module load Gaussian/09-d01] [--gaussian_exe g09 or /apps/all/Gaussian/09-d01/g09/g09]
@@ -195,6 +195,8 @@ Standard Molecular Dynamics Simulation Run:
   --npt_time ps         Time of NPT equilibration in ps
   --nvt_time ps         Time of NVT equilibration in ps
   --seed int            seed
+  --box_type cubic      Box shape for solvation
+  --box_distance nm     Distance in nm between solute and box edge
   --no_dr               Turn off the acdoctor mode and do not check/diagnose problems in the input ligand file in the next attempt if the regular antechamber run for
                         ligand preparation fails (ligand_mol2prep.sh script related issues). Use this argument carefully and ensure that you provide valid structures
   --not_clean_backup_files

--- a/changelog.md
+++ b/changelog.md
@@ -40,3 +40,4 @@
 - allow to provide arguments through config.yml for run_md, run_prolif, run_gbsa
 - fix minor bug with steps - allow to run run_md steps 2,3,4 without --wdir_to_continue if step 1 is also provided
 - added gmx_MMPBSA residue decomposition analysis feature
+- allow specifying solvation box shape and edge distance from the CLI

--- a/streamd/preparation/complex_preparation.py
+++ b/streamd/preparation/complex_preparation.py
@@ -9,8 +9,6 @@ from streamd.preparation.md_files_preparation import prep_md_files, add_ligands_
     edit_topology_file, prepare_mdp_files, check_if_info_already_added_to_topol
 from streamd.utils.utils import run_check_subprocess
 
-from glob import glob
-
 
 def complex_preparation(protein_gro, ligand_gro_list, out_file):
     """Merge protein and ligand GRO files into a single complex structure."""
@@ -35,8 +33,13 @@ def complex_preparation(protein_gro, ligand_gro_list, out_file):
 def run_complex_preparation(wdir_var_ligand, wdir_system_ligand_list,
                             protein_name, wdir_protein, wdir_md, script_path, project_dir,
                             mdtime_ns, npt_time_ps, nvt_time_ps, clean_previous, seed, bash_log,
+                            box_type='cubic', box_distance=1.0,
                             mdp_dir=None, explicit_args=(), env=None):
-    """Prepare all input files for MD by combining protein and ligand data."""
+    """Prepare all input files for MD by combining protein and ligand data.
+
+    :param box_type: Shape of the simulation box used by ``gmx editconf``.
+    :param box_distance: Minimum distance in nm between solute and box edge.
+    """
     wdir_md_cur, md_files_dict = prep_md_files(wdir_var_ligand=wdir_var_ligand, protein_name=protein_name,
                                                wdir_system_ligand_list=wdir_system_ligand_list,
                                                wdir_protein=wdir_protein,
@@ -57,10 +60,10 @@ def run_complex_preparation(wdir_var_ligand, wdir_system_ligand_list,
         add_ligands_to_topol(md_files_dict['itp'], md_files_dict['posres'], md_files_dict['resid'],
                              topol=os.path.join(wdir_md_cur, "topol.top"))
         if not check_if_info_already_added_to_topol(os.path.join(wdir_md_cur, "topol.top"),
-                                                    f'; Include all topology\n#include "all.itp"\n'):
+                                                    '; Include all topology\n#include "all.itp"\n'):
             edit_topology_file(topol_file=os.path.join(wdir_md_cur, "topol.top"),
                                pattern="; Include forcefield parameters",
-                               add=f'; Include all topology\n#include "all.itp"\n',
+                               add='; Include all topology\n#include "all.itp"\n',
                                how='after', n=3)
 
         # create file with molid resid for each ligand in the current system
@@ -94,7 +97,8 @@ def run_complex_preparation(wdir_var_ligand, wdir_system_ligand_list,
     #         shutil.copy(mdp_file, wdir_md_cur)
 
     if not os.path.isfile(os.path.join(wdir_md_cur, 'solv_ions.gro')):
-        cmd = (f'wdir={wdir_md_cur} bash {os.path.join(project_dir, "scripts/script_sh/solv_ions.sh")} '
+        cmd = (f'wdir={wdir_md_cur} box_type={box_type} box_distance={box_distance} '
+               f'bash {os.path.join(project_dir, "scripts/script_sh/solv_ions.sh")} '
                f'>> {os.path.join(wdir_md_cur, bash_log)} 2>&1')
         if not run_check_subprocess(cmd=cmd, key=wdir_md_cur, log=os.path.join(wdir_md_cur, bash_log), env=env):
             return None

--- a/streamd/run_md.py
+++ b/streamd/run_md.py
@@ -220,7 +220,7 @@ def continue_md_from_dir(wdir_to_continue, tpr, cpt, xtc, deffnm, deffnm_next,
             # md_out_cont.part0002.xtc and md_out_cont.tpr
             deffnm_part = os.path.basename(part_xtc).split('.part')[0]
             logging.info(deffnm_part)
-            if re.findall(f'\.part[0-9]*\.xtc', part_xtc):
+            if re.findall(r'\.part[0-9]*\.xtc', part_xtc):
                 # not merged part
                 new_xtc = os.path.join(wdir_to_continue, f'{deffnm_part}.xtc')
                 merge_parts_of_simulation(start_xtc=xtc,
@@ -282,7 +282,7 @@ def start(protein, wdir, lfile, system_lfile, noignh, no_dr,
           activate_gaussian, gaussian_exe, gaussian_basis, gaussian_memory,
           metal_resnames, metal_charges, mcpbpy_cut_off,
           seed, steps, hostfile, ncpu, mdrun_per_node, compute_device, gpu_ids, ntmpi_per_gpu, clean_previous,
-          not_clean_backup_files, unique_id,
+          not_clean_backup_files, unique_id, box_type='cubic', box_distance=1.0,
           active_site_dist=5.0, save_traj_without_water=False,
           explicit_args=(), mdp_dir=None, bash_log=None):
     """Run StreaMD pipeline.
@@ -296,6 +296,8 @@ def start(protein, wdir, lfile, system_lfile, noignh, no_dr,
     :param forcefield_name: Force field to use for preparation.
     :param clean_previous: Whether to remove previous MD files.
     :param mdtime_ns: Simulation time in nanoseconds.
+    :param box_type: Shape of the simulation box used in solvation.
+    :param box_distance: Minimum distance in nm between solute and box edge.
     :param npt_time_ps: Equilibration NPT time in picoseconds.
     :param nvt_time_ps: Equilibration NVT time in picoseconds.
     :param topol: Optional topology file.
@@ -389,7 +391,7 @@ def start(protein, wdir, lfile, system_lfile, noignh, no_dr,
                               f'-p {os.path.join(wdir_protein, "topol.top")} -ff {forcefield_name} >> {os.path.join(wdir_protein, bash_log)} 2>&1'
                         if not run_check_subprocess(cmd, protein, log=os.path.join(wdir_protein, bash_log), env=os.environ.copy()):
                             return None
-                        logging.info(f'Successfully finished protein preparation\n')
+                        logging.info('Successfully finished protein preparation\n')
                     else:
                         target_path = os.path.join(wdir_protein, os.path.basename(protein))
                         if not os.path.isfile(target_path):
@@ -499,6 +501,7 @@ def start(protein, wdir, lfile, system_lfile, noignh, no_dr,
                                          clean_previous=clean_previous, wdir_md=wdir_md,
                                          script_path=script_mdp_path, project_dir=project_dir, mdtime_ns=mdtime_ns,
                                          npt_time_ps=npt_time_ps, nvt_time_ps=nvt_time_ps,
+                                         box_type=box_type, box_distance=box_distance,
                                          mdp_dir=mdp_dir, explicit_args=explicit_args,
                                          bash_log=bash_log, seed=seed, env=os.environ.copy()):
                         if res:
@@ -694,6 +697,10 @@ def main():
                         help='Time of NVT equilibration in ps. Default: 1000 ps.')
     parser1.add_argument('--seed', metavar='int', required=False, default=-1, type=int,
                         help='seed')
+    parser1.add_argument('--box_type', metavar='cubic', required=False, default='cubic',
+                        help='Box shape for solvation')
+    parser1.add_argument('--box_distance', metavar='nm', required=False, default=1.0, type=float,
+                        help='Distance in nm between solute and box edge')
     parser1.add_argument('--no_dr', action='store_true', default=False,
                          help='Turn off the acdoctor mode and do not check/diagnose problems in the input ligand file '
                               'in the next attempt if the regular antechamber run for ligand preparation fails (ligand_mol2prep.sh script related issues). '
@@ -787,7 +794,7 @@ def main():
     if args.steps is not None:
         if not all([i in [1, 2, 3, 4] for i in args.steps]):
             raise ValueError(f'--steps {args.steps} argument is not valid. Please choose the combination from: 1, 2, 3, 4')
-        if not 1 in args.steps and any([i in [2, 3, 4] for i in args.steps]) and args.wdir_to_continue is None:
+        if 1 not in args.steps and any([i in [2, 3, 4] for i in args.steps]) and args.wdir_to_continue is None:
             raise ValueError(f'--wdir_to_continue argument is not valid. '
                          f'If you set up --step {args.steps} you need to provide directories containing md files'
                          f' created by previous steps')
@@ -840,6 +847,7 @@ def main():
               gaussian_basis=args.gaussian_basis, gaussian_memory=args.gaussian_memory,
               hostfile=args.hostfile, ncpu=ncpu, mdrun_per_node=args.mdrun_per_node, compute_device=args.device,
               gpu_ids=args.gpu_ids, ntmpi_per_gpu=args.ntmpi_per_gpu, wdir=wdir, seed=args.seed, steps=args.steps,
+              box_type=args.box_type, box_distance=args.box_distance,
               clean_previous=args.clean_previous_md, not_clean_backup_files=args.not_clean_backup_files,
               metal_resnames=args.metal_resnames, metal_charges=args.metal_charges,
               mcpbpy_cut_off=args.metal_cutoff, unique_id=unique_id,

--- a/streamd/scripts/script_sh/solv_ions.sh
+++ b/streamd/scripts/script_sh/solv_ions.sh
@@ -4,7 +4,9 @@
 
 >&2 echo 'Script running:***************************** Solvation step *********************************'
 cd $wdir
-gmx editconf -f complex.gro -o newbox.gro -c -d 1.0 -bt cubic || { echo "Failed to run command  at line ${LINENO} of ${BASH_SOURCE}" && exit 1; }
+box_type=${box_type:-cubic}
+box_distance=${box_distance:-1.0}
+gmx editconf -f complex.gro -o newbox.gro -c -d "$box_distance" -bt "$box_type" || { echo "Failed to run command  at line ${LINENO} of ${BASH_SOURCE}" && exit 1; }
 #gmx editconf -f complex.gro -o newbox.gro -bt dodecahedron -d 1.2 #Warning about bad box - wrong number of atoms (https://gromacs.org-gmx-users.maillist.sys.kth.narkive.com/q4NXMAoY/bad-box-error) Lena version
 gmx solvate -cp newbox.gro -cs spc216.gro -p topol.top -o solv.gro || { echo "Failed to run command  at line ${LINENO} of ${BASH_SOURCE}" && exit 1; }
 


### PR DESCRIPTION
## Summary
- add `--box_type` and `--box_distance` options to `run_md` CLI
- wire box parameters through preparation pipeline and solvation script
- document new configuration options

## Testing
- `ruff check streamd/preparation/complex_preparation.py streamd/run_md.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af74113b84832ba795724973b735df