### PR TITLE
Add Sphinx documentation and Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![StreaMD Logo](./streamd_logo.png)
 # StreaMD: a tool to perform high-throughput automated molecular dynamics simulations
 
+See the full documentation on [Read the Docs](https://streamd.readthedocs.io).
+
 ## Table Of Contents
 - [Installation](#installation)
 - [Description](#description)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,10 @@
+# API Reference
+
+This section contains the automatically generated API documentation for StreaMD.
+
+```{autosummary}
+:toctree: generated
+:recursive:
+
+streamd
+```

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+# Changelog
+
+```{include} ../changelog.md
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'StreaMD'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.autosummary',
+    'myst_parser',
+]
+autosummary_generate = True
+html_theme = 'sphinx_rtd_theme'
+# Include both docstring sections
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# StreaMD Documentation
+
+Welcome to the documentation for **StreaMD**, a toolkit for high-throughput molecular dynamics simulations.
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+user_guide
+api
+changelog
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+myst-parser
+sphinx-rtd-theme

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,4 @@
+# User Guide
+
+```{include} ../README.md
+```


### PR DESCRIPTION
## Summary
- Set up Sphinx documentation with Read the Docs theme
- Include user guide, API reference, and changelog
- Add Read the Docs build configuration and link from README

## Testing
- `sphinx-build -b html docs docs/_build`

------
https://chatgpt.com/codex/tasks/task_e_68b0615ffae4832b92cfc9d1a9dcce4c